### PR TITLE
Fix Debug derivations

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,7 +15,7 @@ struct State {
     inner: tokio::sync::Mutex<Tracked>,
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct Tracked {
     name: Option<String>,
     region: Option<String>,

--- a/src-tauri/src/riot_client.rs
+++ b/src-tauri/src/riot_client.rs
@@ -9,6 +9,12 @@ pub struct RiotClient {
     api: RiotApi,
 }
 
+impl std::fmt::Debug for RiotClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RiotClient").finish()
+    }
+}
+
 impl RiotClient {
     pub fn new(key: &str) -> Self {
         Self {


### PR DESCRIPTION
## Summary
- implement `Debug` manually for `RiotClient`
- derive `Debug` for `Tracked`

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml --no-default-features` *(fails: the system library `glib-2.0` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f704e4a288323a33c8dbb58801c54