### PR TITLE
Use Riot ID for account lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This app shows League of Legends stats for a tracked summoner.
 1. `npm install`
 2. Copy `.env.example` to `.env` and set your `RIOT_API_KEY`.
 3. Run with `cargo tauri dev` or `npm run tauri`.
-4. In the dashboard view, enter your summoner name and region to start tracking.
+4. In the dashboard view, enter your **Riot ID** (game name and tag line) and region to start tracking.
 
 ## Recommended IDE Setup
 

--- a/src-tauri/src/riot_client.rs
+++ b/src-tauri/src/riot_client.rs
@@ -26,16 +26,31 @@ impl RiotClient {
         PlatformRoute::from_str(region).expect("invalid region")
     }
 
-    pub async fn get_summoner_by_name(
+
+    pub async fn get_account_by_riot_id(
         &self,
-        name: &str,
+        game_name: &str,
+        tag_line: &str,
         region: &str,
-    ) -> Result<riven::models::summoner_v4::Summoner, RiotApiError> {
-        let route = Self::parse_region(region);
-        let path = format!("/lol/summoner/v4/summoners/by-name/{}", name);
+    ) -> Result<Option<riven::models::account_v1::Account>, RiotApiError> {
+        let route = Self::parse_region(region).to_regional();
+        let path = format!("/riot/account/v1/accounts/by-riot-id/{}/{}", game_name, tag_line);
         let req = self.api.request(Method::GET, route.into(), &path);
         self.api
-            .execute_val("summoner-v4.getBySummonerName", route.into(), req)
+            .execute_opt("account-v1.getByRiotId", route.into(), req)
+            .await
+    }
+
+    pub async fn get_summoner_by_puuid(
+        &self,
+        puuid: &str,
+        region: &str,
+    ) -> Result<Option<riven::models::summoner_v4::Summoner>, RiotApiError> {
+        let route = Self::parse_region(region);
+        let path = format!("/lol/summoner/v4/summoners/by-puuid/{}", puuid);
+        let req = self.api.request(Method::GET, route.into(), &path);
+        self.api
+            .execute_opt("summoner-v4.getByPUUID", route.into(), req)
             .await
     }
 

--- a/src/components/dashboard/SummonerForm.tsx
+++ b/src/components/dashboard/SummonerForm.tsx
@@ -4,12 +4,13 @@ import { useStore } from '../../store';
 import { invoke } from '@tauri-apps/api/core';
 
 export default function SummonerForm() {
-  const { summonerName, region, setSummoner, setDashboard } = useStore();
-  const [name, setName] = useState(summonerName);
+  const { gameName, tagLine, region, setSummoner, setDashboard } = useStore();
+  const [game, setGame] = useState(gameName);
+  const [tag, setTag] = useState(tagLine);
   const [reg, setReg] = useState(region);
 
   const handleSave = async () => {
-    await setSummoner(name, reg);
+    await setSummoner(game, tag, reg);
     const data = await invoke('refresh_dashboard');
     setDashboard(data as any);
   };
@@ -18,8 +19,12 @@ export default function SummonerForm() {
     <Box mb={4}>
       <HStack alignItems="flex-end" spacing={2}>
         <FormControl>
-          <FormLabel>Summoner Name</FormLabel>
-          <Input value={name} onChange={(e) => setName(e.target.value)} />
+          <FormLabel>Game Name</FormLabel>
+          <Input value={game} onChange={(e) => setGame(e.target.value)} />
+        </FormControl>
+        <FormControl w="100px">
+          <FormLabel>Tag Line</FormLabel>
+          <Input value={tag} onChange={(e) => setTag(e.target.value)} />
         </FormControl>
         <FormControl w="120px">
           <FormLabel>Region</FormLabel>

--- a/src/store.ts
+++ b/src/store.ts
@@ -13,25 +13,27 @@ interface AppState {
   mode: Mode;
   dashboard: DashboardStats | null;
   matchData: MatchPayload | null;
-  summonerName: string;
+  gameName: string;
+  tagLine: string;
   region: string;
   setMode: (val: Mode) => void;
   setDashboard: (d: DashboardStats | null) => void;
   setMatchData: (m: MatchPayload | null) => void;
-  setSummoner: (name: string, region: string) => Promise<void>;
+  setSummoner: (gameName: string, tagLine: string, region: string) => Promise<void>;
 }
 
 export const useStore = create<AppState>((set) => ({
   mode: 'dashboard',
   dashboard: null,
   matchData: null,
-  summonerName: '',
+  gameName: '',
+  tagLine: '',
   region: 'NA1',
   setMode: (mode) => set({ mode }),
   setDashboard: (dashboard) => set({ dashboard }),
   setMatchData: (matchData) => set({ matchData }),
-  setSummoner: async (name, region) => {
-    await invoke('set_tracked_summoner', { name, region });
-    set({ summonerName: name, region });
+  setSummoner: async (gameName, tagLine, region) => {
+    await invoke('set_tracked_summoner', { gameName, tagLine, region });
+    set({ gameName, tagLine, region });
   },
 }));


### PR DESCRIPTION
## Summary
- update README to reference Riot ID entry
- update store state for gameName/tagLine
- adjust SummonerForm inputs for game name and tag line
- replace summoner-name Riot API calls with Riot ID based lookup

## Testing
- `npm run build`
- `cargo check` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_686f76cdc0388323892655f0d6045de3