### PR TITLE
Implement compact dashboard with recent games

### DIFF
--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -3,6 +3,7 @@ import { DashboardStats } from '../../store';
 import ChampionStats from './ChampionStats';
 import SummonerForm from './SummonerForm';
 import RankCard from './RankCard';
+import RecentGames from './RecentGames';
 
 interface Props {
   data: DashboardStats | null;
@@ -10,11 +11,12 @@ interface Props {
 
 export default function DashboardView({ data }: Props) {
   return (
-    <Box p={4}>
+    <Box p={4} maxW="500px" mx="auto">
       <VStack align="stretch" spacing={4}>
         <SummonerForm />
         <RankCard rank={data?.rank} />
         <ChampionStats champions={data?.champions || []} />
+        <RecentGames />
       </VStack>
     </Box>
   );

--- a/src/components/dashboard/RankCard.tsx
+++ b/src/components/dashboard/RankCard.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, Stat, StatLabel, StatNumber, StatHelpText } from '@chakra-ui/react';
+import { Box, Text, Stat, StatLabel, StatNumber, StatHelpText, CircularProgress, CircularProgressLabel, HStack } from '@chakra-ui/react';
 import { RankInfo } from '../../store';
 
 interface Props {
@@ -18,15 +18,20 @@ export default function RankCard({ rank }: Props) {
 
   return (
     <Box borderWidth="1px" p={2} borderRadius="md">
-      <Stat>
-        <StatLabel>
-          {rank.tier} {rank.rank}
-        </StatLabel>
-        <StatNumber>{rank.lp} LP</StatNumber>
-        <StatHelpText>
-          {rank.wins}W/{rank.losses}L - {winrate}% WR
-        </StatHelpText>
-      </Stat>
+      <HStack>
+        <CircularProgress value={parseFloat(winrate)} size="60px" color="green.400">
+          <CircularProgressLabel>{winrate}%</CircularProgressLabel>
+        </CircularProgress>
+        <Stat ml={2}>
+          <StatLabel>
+            {rank.tier} {rank.rank}
+          </StatLabel>
+          <StatNumber>{rank.lp} LP</StatNumber>
+          <StatHelpText>
+            {rank.wins}W/{rank.losses}L
+          </StatHelpText>
+        </Stat>
+      </HStack>
     </Box>
   );
 }

--- a/src/components/dashboard/RecentGames.tsx
+++ b/src/components/dashboard/RecentGames.tsx
@@ -1,0 +1,42 @@
+import { Box, Heading, Table, Tbody, Td, Th, Thead, Tr, Badge } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { GameSummary } from '../../store';
+
+export default function RecentGames() {
+  const [games, setGames] = useState<GameSummary[]>([]);
+
+  useEffect(() => {
+    invoke<GameSummary[]>('recent_games', { count: 10 }).then(setGames).catch(() => setGames([]));
+  }, []);
+
+  if (!games.length) {
+    return null;
+  }
+
+  return (
+    <Box>
+      <Heading size="md" mb={2}>Recent Games</Heading>
+      <Table size="sm">
+        <Thead>
+          <Tr>
+            <Th>Champion</Th>
+            <Th>K/D/A</Th>
+            <Th isNumeric>Duration</Th>
+            <Th>Result</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {games.map((g, i) => (
+            <Tr key={i}>
+              <Td>{g.champion_id}</Td>
+              <Td>{`${g.kills}/${g.deaths}/${g.assists}`}</Td>
+              <Td isNumeric>{Math.round(g.duration / 60)}m</Td>
+              <Td>{g.win ? <Badge colorScheme="green">W</Badge> : <Badge colorScheme="red">L</Badge>}</Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </Box>
+  );
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -20,6 +20,15 @@ export interface DashboardStats {
   champions: ChampionStat[];
   rank?: RankInfo | null;
 }
+
+export interface GameSummary {
+  champion_id: number;
+  win: boolean;
+  kills: number;
+  deaths: number;
+  assists: number;
+  duration: number;
+}
 export interface MatchPayload {
   game: any;
   ranked: any[][];

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -5,6 +5,20 @@ const config: ThemeConfig = {
   useSystemColorMode: true,
 };
 
-const theme = extendTheme({ config });
+// Custom color palette matching League style
+const colors = {
+  primary: '#0F2027',
+  secondary: '#C89B3C',
+  success: '#0A8754',
+  danger: '#D32F2F',
+  info: '#0F77B6',
+};
 
-export default theme;
+const fonts = {
+  heading: 'Inter, sans-serif',
+  body: 'Inter, sans-serif',
+};
+
+const customTheme = extendTheme({ config, colors, fonts });
+
+export default customTheme;


### PR DESCRIPTION
## Summary
- update theme with League colors
- show winrate with progress indicator
- add recent games table
- fetch recent matches from backend

## Testing
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: `gdk-3.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f83e861bc8323b3951b1cb321af7e