### PR TITLE
Use latest champion data from Data Dragon

### DIFF
--- a/src/components/dashboard/RecentGames.tsx
+++ b/src/components/dashboard/RecentGames.tsx
@@ -29,7 +29,7 @@ export default function RecentGames() {
         <Tbody>
           {games.map((g, i) => (
             <Tr key={i}>
-              <Td>{g.champion_id}</Td>
+              <Td>{g.champion_name}</Td>
               <Td>{`${g.kills}/${g.deaths}/${g.assists}`}</Td>
               <Td isNumeric>{Math.round(g.duration / 60)}m</Td>
               <Td>{g.win ? <Badge colorScheme="green">W</Badge> : <Badge colorScheme="red">L</Badge>}</Td>

--- a/src/store.ts
+++ b/src/store.ts
@@ -23,6 +23,7 @@ export interface DashboardStats {
 
 export interface GameSummary {
   champion_id: number;
+  champion_name: string;
   win: boolean;
   kills: number;
   deaths: number;


### PR DESCRIPTION
## Summary
- fetch most recent Data Dragon version for champions
- include champion name on recent games response
- show champion names in recent games table

## Testing
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f891cb6888323aad8b677394fd1ab