### PR TITLE
Fix rank points unwrap error

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -178,7 +178,7 @@ async fn refresh_dashboard() -> Result<serde_json::Value, String> {
                     .as_ref()
                     .map(|r| r.to_string())
                     .unwrap_or_default(),
-                lp: e.league_points.unwrap_or(0) as u32,
+                lp: e.league_points as u32,
                 wins,
                 losses,
                 winrate,


### PR DESCRIPTION
## Summary
- adjust rank points calculation to use the `i32` value directly

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: webkit2gtk-4.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_686f92249fb8832386c536bb49b1baf2